### PR TITLE
Add support to rescale animated PNG(APNG)/GIF/WEBP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
     name: PyTest
     needs: [Lint]
     runs-on: ubuntu-latest
+    env:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SENTRY_ENVIRONMENT: ${{ secrets.SENTRY_ENVIRONMENT }}
 
     steps:
       - name: Checkout

--- a/remote/app.py
+++ b/remote/app.py
@@ -93,13 +93,13 @@ def setup_logger(flask_app: Flask):
     we use this(`Flask.logger`) instead of others(`logging`/`print`/...)
     to print logs within the whole project.
     """
-    _loger = logging.getLogger(flask_app.name)
+    _logger = logging.getLogger(flask_app.name)
 
     level = logging.INFO
     if flask_app.debug or flask_app.testing:
         level = logging.DEBUG
     level = flask_app.config.get("LOG_LEVEL".upper(), level)
-    _loger.setLevel(level)
+    _logger.setLevel(level)
     # TODO set logger format
 
 

--- a/remote/blueprints/image.py
+++ b/remote/blueprints/image.py
@@ -233,9 +233,7 @@ def _need_rescale(img: Image.Image, target_size: int) -> bool:
     return img.size[0] >= target_size and img.size[1] >= target_size
 
 
-def _rescale_single_frame_avatar(
-    image: Image.Image, size: AvatarSize
-) -> bytes | None:
+def _rescale_single_frame_avatar(image: Image.Image, size: AvatarSize) -> bytes | None:
     try:
         with io.BytesIO() as io_obj:
             rescaled = resizeimage.resize_cover(image, (size, size), validate=False)

--- a/remote/utilities/image.py
+++ b/remote/utilities/image.py
@@ -244,10 +244,13 @@ class ImageHandle:
             exif = self.image.getexif() or {}
             for tag in tags:
                 exif.pop(tag.value, None)
+        return self
 
+    # See also: https://stackoverflow.com/questions/33533148/
     def auto_rotate(self):
         """Auto-rotate the image according to its EXIF data."""
         if not self.image:
             current_app.logger.warning("No image found, skip auto rotate.")
             return
         self.image = ImageOps.exif_transpose(self.image)
+        return self

--- a/remote/utilities/image.py
+++ b/remote/utilities/image.py
@@ -122,12 +122,15 @@ class ImageHandle:
         self._raw_content: bytes = content
         self.mime: Optional[ImageMIME] = None
         self.image: Image.Image = None
-        self.animated: bool = False
         self.preprocess()
 
     @property
     def is_valid(self) -> bool:
         return self.mime is not None and self.image is not None
+
+    @property
+    def is_animated(self) -> bool:
+        return getattr(self.image, "is_animated", False)
 
     @property
     def raw_size(self) -> int:
@@ -149,7 +152,7 @@ class ImageHandle:
         """Convert rare image formats into formats supported by PIL."""
         self.mime = self.guess_mime_from_bytes(self._raw_content)
         if not self.mime:
-            current_app.logger.info("No MIME type found, skip ths preparation process.")
+            current_app.logger.info("No MIME type found, skip the preparation process.")
             return
 
         # PIL only support rasterized image formats, convert SVG to PNG first.
@@ -194,9 +197,6 @@ class ImageHandle:
         else:
             self.image = image
             self.image.format = self.mime.pil_format
-
-        if getattr(self.image, "is_animated", False):
-            self.animated = True
 
     @staticmethod
     def guess_mime_from_bytes(buffer: bytes) -> ImageMIME | None:


### PR DESCRIPTION
## PNG(APNG)
- [X] Animated input
- [ ] Correctly setting (resized) default image for generated content
- [ ] Compression size check
- [ ] BUG: output can be broken even the frames themselves are properly processed
- [X] Animated output

## GIF
- [X] Animated input
- [X] ~~Investigate if pasted _additive_ frame needs to be aligned according to GIF tile info~~ Partial frames seem to be deprecated
- [X] Animated output

## WEBP
- [X] Animated input
- [X] Animated output

## Functions
- [X] Animated controlled by URL search parameter `?animated=1`
- [X] Support for avatar
- [X] Support for resize (fit)
- [ ] Cleanup
